### PR TITLE
Adjust basic pages to use of GitHub (GH-8)

### DIFF
--- a/help.rst
+++ b/help.rst
@@ -16,27 +16,14 @@ usage then please check the rest of this guide first as it should answer your
 question.
 
 
-Ask #jython
------------
-
-If you are comfortable with IRC you can try asking on ``#jython`` (on
-the `freenode`_ network). Often there are experienced developers around,
-ranging from triagers to core developers, who can answer questions about
-developing for Jython, although it helps to be patient as it sometimes
-takes a little while for a question to get noticed.
-
-.. _freenode: http://freenode.net/
-
-
 Core Mentorship
 ---------------
 
 If you are interested in improving Jython and contributing to its development,
 but don’t yet feel entirely comfortable with the public channels mentioned
-above, `Python Mentors`_ are here to help you.  The Python Mentors list was
-originally created to help with CPython development, but since Jython shares
-most of the same infrastructure (Jython's repository is at hg.python.org
-and uses a related Roundup issue tracker) it is a good place to find help for
+above, `Python Mentors`_ may be there to help you.  The Python Mentors list was
+originally created to help with CPython development, but since Jython an
+implementation acknowledgef by the PSF, it may be a good place to find help for
 Jython as well. Python is fortunate to have a community of volunteer core
 developers willing to mentor anyone wishing to contribute code, work on bug
 fixes or improve documentation.  Everyone is welcomed and encouraged to
@@ -44,7 +31,7 @@ contribute.
 
 .. _Python Mentors: http://pythonmentors.com
 
-.. FIXME: would Python Mentors count themselves a good place to go fro Jython?
+.. FIXME: would Python Mentors count themselves a good place to go for Jython?
 
 Mailing Lists
 -------------
@@ -63,11 +50,12 @@ File a Bug
 
 If you strongly suspect you have stumbled on a bug (be it in the build
 process, in the test suite, or in other areas), then open an issue on the
-`Jython issue tracker`_.  As with every bug report it is strongly advised that
+`Jython GitHub repository`_.  As with every bug report it is strongly advised that
 you detail which conditions triggered it (including the OS name and version,
 which JVM and version, and what you were trying to do), as well as the exact
 error message you encountered.
 
+.. _Jython GitHub repository: https://github.com/jython/jython
 .. _Jython issue tracker: http://bugs.jython.org
 
 .. _jython-users: https://lists.sourceforge.net/lists/listinfo/jython-users

--- a/index.rst
+++ b/index.rst
@@ -2,7 +2,7 @@
    Normally this would mean a new file index_jy.rst, but index.rst is the
    starting point for the documentation.
    We therefore keep it as modified, although merging changes from the CPython
-   devguide difficult for this file.
+   devguide will be difficult for this file.
 
 ========================
 Jython Developer's Guide
@@ -10,14 +10,16 @@ Jython Developer's Guide
 
 This guide is a comprehensive resource for :ref:`contributing <contributing>`
 to Jython_ -- for both new and experienced contributors.
-It has been adapted from the CPython Developer's Guide and the reader should
+It has been (somewhat incompletely)
+adapted from the CPython Developer's Guide and the reader should
 bear in mind that:
 
-*  The CPython process is PR-based on GitHub and this guide anticipates our
-   adoption of that for Jython.
-*  The existing Jython process uses Mercurial so the guide describes that too.
+*  The Jython process, like CPython's, is based GitHub PRs,
+   but Jython does not have the same set of tool integrations.
+*  Jython migrated from Mercurial in 2020, much later than CPython,
+   so Jython-specific parts of the guide may refer to the old process.
 *  Statements about "Python" should apply to both CPython and Jython.
-*  The adaptation is imperfect: parts of the guide will say (or mean) CPython.
+   The adaptation is imperfect: parts of the guide will say (or mean) CPython.
 
 This guide is :ref:`maintained <helping-with-the-developers-guide>` by the same
 community that maintains CPython and Jython.
@@ -30,20 +32,9 @@ Quick Reference
 Mercurial
 ^^^^^^^^^
 
-1. :ref:`Get the source code <checkout-jy>`::
+Mercurial is no longer used.
+The previous official repository at ``https://hg.python.org/jython`` is not current.
 
-      hg clone http://hg.python.org/jython
-
-2. :ref:`Build Jython <compiling-jy>`::
-
-      ant
-
-3. :doc:`Run the tests <runtests_jy>`::
-
-      ant regrtest
-
-4. Make the :doc:`patch <patch_hg_jy>`.
-5. Submit it to the `Jython issue tracker`_.
 
 GitHub
 ^^^^^^
@@ -56,7 +47,7 @@ instructions please see the :ref:`setup guide <setup-jy>`.
 1. Install and set up :ref:`Git <vcsetup-jy>` and other dependencies
    (see the :ref:`Get Setup <setup-jy>` page for detailed information).
 
-2. Fork `the Jython repository <https://github.com/jython/jython>`_
+2. Fork the `Jython GitHub repository`_
    to your GitHub account and :ref:`get the source code <checkout-jy>` using::
 
       git clone https://github.com/<your_username>/jython
@@ -72,39 +63,46 @@ instructions please see the :ref:`setup guide <setup-jy>`.
 
 4. :doc:`Run the tests <runtests_jy>`::
 
-      dist/bin/jython -m test -e
+      dist/bin/jython -m test.regrtest -e
 
-   (for Jython 3). With Jython 2.7, replace ``test`` with ``test.regrtest``.
+   This applies for Jython 2.7.
+   To test Jython 3, when it exists, replace ``test.regrtest`` with ``test``.
 
 5. Create a new branch where your work for the issue will go, e.g.::
 
       git checkout -b fix-issue-12345 master
 
-   If an issue does not already exist, please `create it
-   <https://bugs.jython.org/>`_.  Trivial issues (e.g. typo fixes) do not
-   require any issue to be created.
+   If an issue does not already exist, please create it on
+   the `Jython GitHub repository`_.
+   The legacy `bug tracker <https://bugs.jython.org/>`_ still operates
+   (for Jython 2.7 only) but is not preferred.
+   Trivial issues (e.g. typo fixes) do not require any issue to be created:
+   create a PR directly.
 
 6. Once you fixed the issue, run the tests, and if
    everything is ok, commit.
 
-7. Push the branch on your fork on GitHub and :doc:`create a pull request
-   <pullrequest>`.  Include the issue number using ``bpo-NNNN`` in the
-   pull request description.  For example::
-
-      bpo-12345: Fix some bug in spam module
+7. Push the branch to your fork on GitHub and :doc:`create a pull request
+   <pullrequest>`.
+   Include the issue number using GitHub conventions in the pull request
+   description.
+   (Use ``bjo-NNNN`` if it is from the legacy tracker.)
 
 .. note::
 
-   bpo stands for bugs.python.org and these flags are used by CPython's GitHub
-   tools. For Jython we need our own naming convention, and to re-use the
-   CPython tools. It is also worth considering whether we move away from
-   bugs.jython.org to GitHub issues, and how we do that.
+   bpo-NNNN is used by CPython for for bugs.python.org
+   and is picked up by CPython's GitHub tools.
+   For Jython we need our own naming convention, but cannot yet re-use the
+   CPython tools.
+   We intend to move away from bugs.jython.org to GitHub issues more aggressively
+   that CPython has made the switch.
 
 .. note::
 
    First time contributors will need to sign the Contributor Licensing
    Agreement (CLA) as described in the :ref:`Licensing <cla>` section of
    this guide.
+   This requires an account on the CPython's legacy bug tracker.
 
 
 Quick Links
@@ -113,7 +111,7 @@ Quick Links
 Here are some links that you probably will reference frequently while
 contributing to Jython:
 
-* `Jython issue tracker`_
+* `Jython GitHub repository`_ (or maybe the `Jython issue tracker`_)
 * :doc:`help`
 * PEPs_ (Python Enhancement Proposals)
 * :doc:`gitbootcamp`
@@ -123,27 +121,21 @@ contributing to Jython:
 Status of Jython branches
 -------------------------
 
-.. note:: Maybe how it should look in a process based on GitHub,
-   and for Jython 3. Not how it is.
 
-+--------+----------+-------------+---------------+-------------+-----------------------------------------------------------------------------------------------------------------+
-| Branch | Schedule | Status      | First release | End-of-life | Comment                                                                                                         |
-+========+==========+=============+===============+=============+=================================================================================================================+
-| master |          | features    |               |             | The default branch is currently the future Jython 3.5.                                                          |
-+--------+----------+-------------+---------------+-------------+-----------------------------------------------------------------------------------------------------------------+
-| 2.7    |          | bugfix      |               |             | The support has been extended to 2020 (1).                                                                      |
-|        |          |             |               |             | Most recent binary release: `Jython 2.7.1                                                                       |
-|        |          |             |               |             | <http://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.7.1/jython-installer-2.7.1.jar>`_ |
-+--------+----------+-------------+---------------+-------------+-----------------------------------------------------------------------------------------------------------------+
-| 2.5    |          | end-of-life |               |             | Final release: `Jython 2.5.3                                                                                    |
-|        |          |             |               |             | <https://repo1.maven.org/maven2/org/python/jython/2.5.3/>`_                                                     |
-+--------+----------+-------------+---------------+-------------+-----------------------------------------------------------------------------------------------------------------+
++--------+----------+-------------+---------------+-------------+-----------------------------------------------------------------------------+
+| Branch | Schedule | Status      | First release | End-of-life | Comment                                                                     |
++========+==========+=============+===============+=============+=============================================================================+
+| master |          | bugfix      |               |             | PSF support for Python 2 ended in 2020 (see :pep:`373`) but                 |
+|        |          |             |               |             | the most recent release of Jython is still `Jython 2.7.2                    |
+|        |          |             |               |             | <https://search.maven.org/artifact/org.python/jython-installer/2.7.2/jar>`_ |
++--------+----------+-------------+---------------+-------------+-----------------------------------------------------------------------------+
+| 3.8    |          | features    |               |             | This branch is the future of Jython                                         |
+|        |          |             |               |             | (but just a gleam in the eye at present).                                   |
++--------+----------+-------------+---------------+-------------+-----------------------------------------------------------------------------+
+| 2.5    |          | end-of-life |               |             | Final release: `Jython 2.5.3                                                |
+|        |          |             |               |             | <https://repo1.maven.org/maven2/org/python/jython/2.5.3/jar>`_              |
++--------+----------+-------------+---------------+-------------+-----------------------------------------------------------------------------+
 
-(1) The exact date of Python 2.7 end-of-life has not been decided yet. It will
-be decided by Python 2.7 release manager, Benjamin Peterson, who will update
-the :pep:`373`. Read also the `[Python-Dev] Exact date of Python 2 EOL?
-<https://mail.python.org/pipermail/python-dev/2017-March/147655.html>`_ thread
-on python-dev (March 2017).
 
 Status:
 
@@ -163,40 +155,18 @@ have reached end-of-life.
 The Jython project follows the Python Software Foundation in the naming of
 versions of the language (e.g. Jython 2.7 implements Python 2.7), and whether an
 implementation of that version has reached reached end-of-life.
+The third element (micro) has bears no relationship to CPython micro-versions.
 
 See also :ref:`Security branches <secbranch>`.
 
-Each release of Python is tagged in the source repo with a tag of the form
+Jython names its releases in the same scheme as CPython.
+Each release of Jython is tagged in the source repo with a tag of the form
 ``vX.Y.ZTN``, where ``X`` is the major version, ``Y`` is the
 minor version, ``Z`` is the micro version, ``T`` is the release level
 (``a`` for alpha releases, ``b`` for beta, ``rc`` release candidate,
 and *null* for final releases), and ``N`` is the release serial number.
 Some examples of release tags: ``v3.7.0a1``, ``v3.6.3``, ``v2.7.14rc1``.
 
-The code base for a release cycle which has reached end-of-life status
-is frozen and no longer has a branch in the repo.  The final state of
-the end-of-lifed branch is recorded as a tag with the same name as the
-former branch, e.g. ``3.3`` or ``2.6``.  For reference, here are the
-most recently end-of-lifed release cycles:
-
-+------------------+--------------+-------------+----------------+----------------+----------------------------------------------------------------------------+
-| Tag              | Schedule     | Status      | First release  | End-of-life    | Comment                                                                    |
-+==================+==============+=============+================+================+============================================================================+
-| 3.3              | :pep:`398`   | end-of-life | 2012-09-29     | 2017-09-29     | `Final release: Python 3.3.7                                               |
-|                  |              |             |                |                | <https://www.python.org/downloads/release/python-337/>`_                   |
-+------------------+--------------+-------------+----------------+----------------+----------------------------------------------------------------------------+
-| 3.2              | :pep:`392`   | end-of-life | 2011-02-20     | 2016-02-20     | `Final release: Python 3.2.6                                               |
-|                  |              |             |                |                | <https://www.python.org/downloads/release/python-326/>`_                   |
-+------------------+--------------+-------------+----------------+----------------+----------------------------------------------------------------------------+
-| 3.1              | :pep:`375`   | end-of-life | 2009-06-27     | 2012-04-11     | `Final release: Python 3.1.5                                               |
-|                  |              |             |                |                | <https://www.python.org/downloads/release/python-315/>`_                   |
-+------------------+--------------+-------------+----------------+----------------+----------------------------------------------------------------------------+
-| 3.0              | :pep:`361`   | end-of-life | 2008-12-03     | 2009-01-13     | `Final release: Python 3.0.1                                               |
-|                  |              |             |                |                | <https://www.python.org/download/releases/3.0.1/>`_                        |
-+------------------+--------------+-------------+----------------+----------------+----------------------------------------------------------------------------+
-| 2.6              | :pep:`361`   | end-of-life | 2008-10-01     | 2013-10-29     | `Final release: Python 2.6.9                                               |
-|                  |              |             |                |                | <https://www.python.org/download/releases/2.6.9/>`_                        |
-+------------------+--------------+-------------+----------------+----------------+----------------------------------------------------------------------------+
 
 .. _contributing:
 
@@ -297,14 +267,9 @@ Key Resources
 -------------
 
 * Coding style guides
-    * Jython's `Java coding standard <https://wiki.python.org/jython/CodingStandards>`_
+    * Jython's `Java coding standard`_
     * :PEP:`8` (Style Guide for Python Code)
-* `Jython issue tracker`_
-    * `Meta tracker <http://psf.upfronthosting.co.za/roundup/meta>`_ (issue
-      tracker for the issue tracker)
-    * :doc:`experts`
 * Source code
-    * `Browse in Mercurial online <http://hg.python.org/jython/file/default/>`_
     * `Browse in GitHub <https://github.com/jython/jython/>`_
 
 * PEPs_ (Python Enhancement Proposals)
@@ -421,4 +386,6 @@ you understand the Jython one.
 .. _Issue tracker: https://bugs.python.org/
 .. _open pull requests: https://github.com/jython/jython/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20label%3A%22awaiting%20review%22
 .. _Jython issue tracker: https://bugs.jython.org/
+.. _Jython GitHub repository: https://github.com/jython/jython
+.. _Java coding standard: https://wiki.python.org/jython/CodingStandards
 .. _Style Guide for Java code: http://www.oracle.com/technetwork/java/codeconvtoc-136057.html

--- a/index.rst
+++ b/index.rst
@@ -82,7 +82,11 @@ instructions please see the :ref:`setup guide <setup-jy>`.
 6. Once you fixed the issue, run the tests, and if
    everything is ok, commit.
 
-7. Push the branch to your fork on GitHub and :doc:`create a pull request
+7. Push the branch to your fork on GitHub::
+
+      git push -u origin fix-issue-12345
+
+   and :doc:`create a pull request
    <pullrequest>`.
    Include the issue number using GitHub conventions in the pull request
    description.
@@ -129,8 +133,8 @@ Status of Jython branches
 |        |          |             |               |             | the most recent release of Jython is still `Jython 2.7.2                    |
 |        |          |             |               |             | <https://search.maven.org/artifact/org.python/jython-installer/2.7.2/jar>`_ |
 +--------+----------+-------------+---------------+-------------+-----------------------------------------------------------------------------+
-| 3.8    |          | features    |               |             | This branch is the future of Jython                                         |
-|        |          |             |               |             | (but just a gleam in the eye at present).                                   |
+| 3.8    |          | features    |               |             | This branch is the future of Jython.                                        |
+|        |          |             |               |             | (It should be master, but is just a gleam in the eye at present.)           |
 +--------+----------+-------------+---------------+-------------+-----------------------------------------------------------------------------+
 | 2.5    |          | end-of-life |               |             | Final release: `Jython 2.5.3                                                |
 |        |          |             |               |             | <https://repo1.maven.org/maven2/org/python/jython/2.5.3/jar>`_              |

--- a/patch_hg_jy.rst
+++ b/patch_hg_jy.rst
@@ -9,6 +9,7 @@ Lifecycle of a Patch (Mercurial)
 .. note::
    This has been adapted for Jython from an old version of the CPython devguide,
    to describe the Jython process based on Mercurial.
+   We retain this (for the time being) for reference.
 
 Creating
 --------

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -7,18 +7,16 @@ Lifecycle of a Pull Request
 ===========================
 
 .. warning:: At present, this is not much modified from the CPython base.
-   This describes the PR-based process used by CPython on GitHub, which works
-   for Jython in a limited form. (You can submit a PR, but we export a patch.)
-   The traditional Jython process is based on
-   :doc:`patches submitted to the tracker <patch_hg_jy>`.
+   This describes the PR process used by CPython on GitHub,
+   which works for Jython with some adjustment.
 
 Introduction
 ------------
 
-CPython uses a workflow based on pull requests. What this means is
+Jython uses a workflow based on pull requests. What this means is
 that you create a branch in Git, make your changes, push those changes
 to your fork on GitHub (``origin``), and then create a pull request against
-the official CPython repository (``upstream``).
+the official Jython repository (``upstream``).
 
 
 .. _pullrequest-quickguide:
@@ -27,9 +25,9 @@ Quick Guide
 -----------
 
 `Clear communication`_ is key to contributing to any project, especially an
-`Open Source`_ project like CPython.
+`Open Source`_ project like Jython.
 
-Here is a quick overview of how you can contribute to CPython:
+Here is a quick overview of how you can contribute to Jython:
 
 #. `Create an issue`_ that describes your change [*]_
 
@@ -37,7 +35,7 @@ Here is a quick overview of how you can contribute to CPython:
 
 #. Work on changes (e.g. fix a bug or add a new feature)
 
-#. :ref:`Run tests <runtests>` and ``make patchcheck``
+#. :ref:`Run tests <runtests-jy>` and ``make patchcheck``
 
 #. :ref:`Commit <commit-changes>` and :ref:`push <push-changes>`
    changes to your GitHub fork
@@ -49,14 +47,15 @@ Here is a quick overview of how you can contribute to CPython:
 #. When your changes are merged, you can :ref:`delete the PR branch
    <deleting_branches>`
 
-#. Celebrate contributing to CPython! :)
+#. Celebrate contributing to Jython! :)
 
 .. [*] If an issue is trivial (e.g. typo fixes), or if an issue already exists,
        you can skip this step.
 
 .. _Clear communication: https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
 .. _Open Source: https://opensource.guide/
-.. _create an issue: https://bugs.python.org/
+.. _create an issue: https://github.com/jython/jython/issues
+.. _Jython: https://github.com/jython/jython
 .. _CPython: https://github.com/python/cpython
 .. _use HTTPS: https://help.github.com/articles/which-remote-url-should-i-use/
 .. _Create Pull Request: https://help.github.com/articles/creating-a-pull-request/
@@ -79,12 +78,11 @@ You should have already :ref:`set up your system <setup>`,
 
   (Learn more about :ref:`good-prs`)
 
-* Make sure the changes are fine and don't cause any test failure::
+* Make sure the changes don't cause any test failure::
 
-     make patchcheck
-     ./python -m test
+     ./python -m test.regrtest -e
 
-  (Learn more about :ref:`patchcheck` and about :doc:`runtests`)
+  (Learn more about :doc:`runtests_jy`)
 
 * Once you are satisfied with the changes, add the files and commit them::
 
@@ -103,9 +101,9 @@ You should have already :ref:`set up your system <setup>`,
      git rebase upstream/master
      git push --force origin <branch-name>
 
-* Finally go on :samp:`https://github.com/{<your-username>}/cpython`: you will
+* Finally go on :samp:`https://github.com/{<your-username>}/jython`: you will
   see a box with the branch you just pushed and a green button that allows
-  you to create a pull request against the official CPython repository.
+  you to create a pull request against the official Jython repository.
 
 * When people start adding review comments, you can address them by switching
   to your branch, making more changes, committing them, and pushing them to
@@ -137,7 +135,8 @@ When creating a pull request for submission, there are several things that you
 should do to help ensure that your pull request is accepted.
 
 First, make sure to follow Python's style guidelines. For Python code you
-should follow :PEP:`8`, and for C code you should follow :PEP:`7`. If you have
+should follow :PEP:`8`, and for Java code you should follow
+the `Java coding standard`_. If you have
 one or two discrepancies those can be fixed by the core developer who merges
 your pull request. But if you have systematic deviations from the style guides
 your pull request will be put on hold until you fix the formatting issues.
@@ -166,41 +165,7 @@ unknown to you between your changes and some other part of the interpreter.
 Fifth, proper :ref:`documentation <documenting>`
 additions/changes should be included.
 
-
-.. _patchcheck:
-
-``patchcheck``
---------------
-
-``patchcheck`` is a simple automated patch checklist that guides a developer
-through the common patch generation checks. To run ``patchcheck``:
-
-   On *UNIX* (including Mac OS X)::
-
-      make patchcheck
-
-   On *Windows* (after any successful build)::
-
-      python.bat Tools/scripts/patchcheck.py
-
-The automated patch checklist runs through:
-
-* Are there any whitespace problems in Python files?
-  (using ``Tools/scripts/reindent.py``)
-* Are there any whitespace problems in C files?
-* Are there any whitespace problems in the documentation?
-  (using ``Tools/scripts/reindent-rst.py``)
-* Has the documentation been updated?
-* Has the test suite been updated?
-* Has an entry under ``Misc/NEWS.d/next`` been added?
-* Has ``Misc/ACKS`` been updated?
-* Has ``configure`` been regenerated, if necessary?
-* Has ``pyconfig.h.in`` been regenerated, if necessary?
-
-The automated patch check doesn't actually *answer* all of these
-questions. Aside from the whitespace checks, the tool is
-a memory aid for the various elements that can go into
-making a complete patch.
+.. _Java coding standard: https://wiki.python.org/jython/CodingStandards
 
 
 .. _good-commits:
@@ -218,7 +183,7 @@ and for each pull request there may be several commits.  In particular:
 
 Commit messages should follow the following structure::
 
-   bpo-42: the spam module is now more spammy. (GH-NNNN)
+   The spam module is now more spammy. (GH-NNNN)
 
    The spam module sporadically came up short on spam. This change
    raises the amount of spam in the module by making it more spammy.
@@ -228,6 +193,8 @@ of what the purpose of the commit is.  If this is not enough detail for a
 commit, a new paragraph(s) can be added to explain in proper depth what has
 happened (detail should be good enough that a core developer reading the
 commit message understands the justification for the change).
+Brevity (<70 characters) in the first line and a blank one following it
+are important to certain tools, including the GitHub format for change sets.
 
 Check :ref:`the git bootcamp <accepting-and-merging-a-pr>` for further
 instructions on how the commit should look like when merging a pull request.
@@ -245,7 +212,7 @@ license your code for use with Python (you retain the copyright).
 
 .. note::
    You only have to sign this document once, it will then apply to all
-   your further contributions to Python.
+   your further contributions to Jython and CPython.
 
 Here are the steps needed in order to sign the CLA:
 
@@ -373,7 +340,7 @@ to be useful, a code review has to be perfect. This is not the case at
 all! It is helpful to just test the pull request and/or play around with the
 code and leave comments in the pull request or issue tracker.
 
-1. If you have not already done so, get a copy of the CPython repository
+1. If you have not already done so, get a copy of the Jython repository
    by following the :ref:`setup guide <setup>`, build it and run the tests.
 
 2. Check the bug tracker to see what steps are necessary to reproduce

--- a/release_jy.rst
+++ b/release_jy.rst
@@ -84,7 +84,7 @@ Clone the repository to a named sub-directory and ``cd`` into it (Bash):
 
 ..  code-block:: bash
 
-    $ git clone git@github.com:jeff5/jython-nightjar.git work
+    $ git clone git@github.com:jython/jython.git work
     Cloning into 'work'...
     $ cd work
     $ git describe --all

--- a/release_jy.rst
+++ b/release_jy.rst
@@ -57,20 +57,6 @@ The examples in this text were mostly made in Windows PowerShell,
 but Git remote operations are in Git Bash.
 
 
-Clone the Repository
---------------------
-
-Clone the repository to a named sub-directory and ``cd`` into it:
-
-..  code-block:: bash
-
-    $ git clone git@github.com:jeff5/jython-nightjar.git work
-    Cloning into 'work'...
-    $ cd work
-    $ git describe --all
-    heads/master
-
-
 Tool Check
 ----------
 
@@ -78,7 +64,7 @@ We must build with the right version of Java.
 (At the time of writing we target Java 8.)
 At the same time, let's check that we have the tools we need on the path:
 
-.. code-block:: ps1con
+..  code-block:: ps1con
 
     PS git> java -version
     java version "1.8.0_241"
@@ -89,6 +75,25 @@ At the same time, let's check that we have the tools we need on the path:
     libgcrypt 1.8.4
     PS git> git --version
     git version 2.26.2.windows.1
+
+
+Clone the Repository
+--------------------
+
+Clone the repository to a named sub-directory and ``cd`` into it (Bash):
+
+..  code-block:: bash
+
+    $ git clone git@github.com:jeff5/jython-nightjar.git work
+    Cloning into 'work'...
+    $ cd work
+    $ git describe --all
+    heads/master
+
+And in Powershell:
+
+..  code-block:: ps1con
+
     PS git> cd work
     PS work> git log --oneline --graph  -3
     * ba16fbc48 (HEAD -> master, origin/master, origin/HEAD) Swap from hg to git as our SCM tool.
@@ -241,10 +246,11 @@ being careful to observe the conventional pattern
 Note that ``git tag -a`` creates a sort of commit.
 It will need to be pushed eventually,
 but the current state of your repository is still at the change set tagged.
-If something goes wrong after this point, but before the eventual push to the repository,
-requiring changes and a fresh commit,
-it is possible to delete the tag with ``git tag -d v2.7.3a1``.
-Do not `delete a tag after the push`_.
+If something goes wrong after this point but before the eventual push to the repository,
+that requires changes and a fresh commit,
+it is possible to delete the tag with ``git tag -d v2.7.3a1``,
+and make it again at the new tip when you're ready.
+The Git book explains why you should not `delete a tag after the push`_.
 
 We follow CPython in signing the tag with GPG as indicated in :pep:`101`
 and the `CPython release-tools`_.

--- a/release_jy.rst
+++ b/release_jy.rst
@@ -33,7 +33,7 @@ To complete a public release you need the following things:
 You can dry-run this process with only the first pre-requisite (driver JARs),
 and a Mercurial clone of the official repository.
 In that case, be careful not to push any changes.
-(Hint: if you clone from ``https://hg.python.org/jython``,
+(Hint: if you clone from ``https://github.com/jython/jython.git``,
 that will prevent an unintended push.)
 
 .. _Sonatype: https://oss.sonatype.org
@@ -49,27 +49,12 @@ Start in the Right Place
 The path to this directory can get embedded in published files,
 so aim for:
 
-* short (i.e. near a file system root).
+* short (i.e. near a file system root), in the examples ``D:\git``.
 * impersonal (not containing company or personal names).
 * ASCII (even though Jython is pretty good with Unicode now).
 
-The examples in this text were made with Windows PowerShell session starting at ``D:\hg``.
-
-We must build with the right version of Java.
-(At the time of writing we target Java 8.)
-At the same time, let's check that we have the tools we need on the path:
-
-.. code-block:: ps1con
-
-    PS hg> hg version -q
-    Mercurial Distributed SCM (version 3.9.2)
-    PS hg> ant -version
-    Apache Ant(TM) version 1.9.14 compiled on March 12 2019
-    PS hg> java -version
-    java version "1.8.0_211"
-    PS hg> gpg --version
-    gpg (GnuPG) 2.2.17
-    libgcrypt 1.8.4
+The examples in this text were mostly made in Windows PowerShell,
+but Git remote operations are in Git Bash.
 
 
 Clone the Repository
@@ -77,18 +62,39 @@ Clone the Repository
 
 Clone the repository to a named sub-directory and ``cd`` into it:
 
-.. The quotes around arguments in these console sessions are mostly to circumvent
-   shortcomings in the pygments ps1con parser.
+..  code-block:: bash
 
-..  code-block:: ps1con
+    $ git clone git@github.com:jeff5/jython-nightjar.git work
+    Cloning into 'work'...
+    $ cd work
+    $ git describe --all
+    heads/master
 
-    PS hg> hg clone "ssh://hg@hg.python.org/jython" work
-    added 8309 changesets with 33026 changes to 8716 files
-    updating to branch default
-    4212 files updated, 0 files merged, 0 files removed, 0 files unresolved
-    PS hg> cd work
-    PS work> hg id -b
-    default
+
+Tool Check
+----------
+
+We must build with the right version of Java.
+(At the time of writing we target Java 8.)
+At the same time, let's check that we have the tools we need on the path:
+
+.. code-block:: ps1con
+
+    PS git> java -version
+    java version "1.8.0_241"
+    PS git> ant -version
+    Apache Ant(TM) version 1.9.14 compiled on March 12 2019
+    PS git> gpg --version
+    gpg (GnuPG) 2.2.17
+    libgcrypt 1.8.4
+    PS git> git --version
+    git version 2.26.2.windows.1
+    PS git> cd work
+    PS work> git log --oneline --graph  -3
+    * ba16fbc48 (HEAD -> master, origin/master, origin/HEAD) Swap from hg to git as our SCM tool.
+    * ed4965e5e Begin to identify as Jython 2.7.3a1.
+    * faf935172 Added tag v2.7.2 for changeset 925a3cc3b49d
+
 
 .. _changes-preparing-for-a-release:
 
@@ -107,11 +113,11 @@ The following files may need to be updated to match the version you are about to
   * ``jython.release_serial``.
 
   In the language of these properties,
-  version 2.7.2b2 is spelled ``2``, ``7``, ``2``, ``${PY_RELEASE_LEVEL_BETA}``, ``2``.
+  version 2.7.3a1 is spelled ``2``, ``7``, ``3``, ``${PY_RELEASE_LEVEL_ALPHA}``, ``1``.
   Every other expression needing a version number is derived from these 5 values.
 * ``build.gradle``: The version number appears as a simple string property ``version``,
   near the top of the file.
-  Version 2.7.2b2 is simply set like this: ``version = '2.7.2b2'``.
+  Version 2.7.3a1 is simply set like this: ``version = '2.7.3a1'``.
 * ``src/org/python/core/imp.java``: If there has been any compiler change,
   increment the magic number ``APIVersion``.
   This magic declares old compiled files incompatible, forcing a fresh compilation for users.
@@ -132,7 +138,7 @@ The following files may need to be updated to match the version you are about to
         Bugs fixed
           - [ NNNN ] ...
 
-  Replace the first line with the release you are building e,g, "Jython 2.7.2b2".
+  Replace the first line with the release you are building e,g, "Jython 2.7.3a1".
   Add anything necessary to the section "New Features".
   After publication (not now),
   we will add a new, empty, section for the version then under development.
@@ -158,7 +164,7 @@ If you changed anything, commit this set of changes locally:
 
 ..  code-block:: ps1con
 
-    PS work> hg commit -m"Prepare for 2.7.2b2 release."
+    PS work> git commit -m"Prepare for 2.7.3a1 release."
 
 
 Get the JARs
@@ -174,17 +180,17 @@ Find the database driver JARs from reputable sources.
   (The JARs on Maven Central seem to be unofficial postings.)
   For Java 8 use ``ojdbc8.jar``.
 
-Let's assume we put the JARs in ``D:\hg\support``.
+Let's assume we put the JARs in ``D:\git\support``.
 Create an ``ant.properties`` correspondingly:
 
 ..  code-block:: properties
 
     # Ant properties defined externally to the release build.
-    informix.jar = D\:\\hg\\support\\jdbc-4.50.1.jar
-    oracle.jar = D\:\\hg\\support\\ojdbc8.jar
+    informix.jar = D\:\\git\\support\\jdbc-4.50.1.jar
+    oracle.jar = D\:\\git\\support\\ojdbc8.jar
 
 Note that this file is ephemeral and local:
-it is ignored by Mercurial because it is named in ``.hgignore``.
+it is ignored by Mercurial because it is named in ``.gitignore``.
 
 
 Check the Configuration of the Build
@@ -195,13 +201,13 @@ Run the ``full-check`` target, which does some simple checks on the repository:
 ..  code-block:: ps1con
 
     PS work> ant full-check
-    Buildfile: D:\hg\work\build.xml
+    Buildfile: D:\git\work\build.xml
 
     force-snapshot-if-polluted:
 
-         [echo] Change set b9b60766cabe is not tagged v2.7.2b2 - build is a snapshot.
+         [echo] Change set ba16fbc48 is not tagged v2.7.3a1 - build is a snapshot.
 
-         [echo] jython.version            = '2.7.2b2-SNAPSHOT'
+         [echo] jython.version            = '2.7.3a1-SNAPSHOT'
 
 It makes an extensive dump, in which two lines like those above matter particularly.
 See that ``build.xml`` has worked out the version string correctly,
@@ -230,35 +236,57 @@ being careful to observe the conventional pattern
 
 ..  code-block:: ps1con
 
-    PS work> hg tag v2.7.2b2
+    PS work> git tag -a -s v2.7.3a1 -m"Jython 2.7.3a1"
 
-Note that ``hg tag`` creates a commit, on top of the one tagged,
-that contains the change to ``.hgtags`` to define the tag.
-This means that the current state of your repository is one commit beyond the one tagged.
+Note that ``git tag -a`` creates a sort of commit.
+It will need to be pushed eventually,
+but the current state of your repository is still at the change set tagged.
+If something goes wrong after this point, but before the eventual push to the repository,
+requiring changes and a fresh commit,
+it is possible to delete the tag with ``git tag -d v2.7.3a1``.
+Do not `delete a tag after the push`_.
+
+We follow CPython in signing the tag with GPG as indicated in :pep:`101`
+and the `CPython release-tools`_.
+See the section :ref:`PGP-signing` for how to generate a key.
+(If you are doing a dry-run you can avoid the signing by dropping the `-s` option.)
+
+As explained in `signing Git commits with GPG`_,
+``gpg`` as supplied with *Git for Windows*
+and *GnuPG for Windows* disagree about the location of your keys.
+In order for signing to work,
+it may be necessary to prepare your installation of Git (one time only)
+to select the full version of *GnuPG for Windows* as follows.
+
+..  code-block:: ps1con
+
+    git config --global gpg.program $env:localappdata\gnupg\bin\gpg.exe
+
+
+.. _signing Git commits with GPG: https://jamesmckay.net/2016/02/signing-git-commits-with-gpg-on-windows/
+.. _CPython release-tools: https://github.com/python/release-tools
+.. _delete a tag after the push: https://git-scm.com/docs/git-tag#_discussion
 
 
 Ant Build for Release
 ---------------------
 
-Update to the change set you tagged, and run the ``full-check`` target again:
+Run the ``full-check`` target again:
 
 ..  code-block:: ps1con
 
-    PS work> hg update v2.7.2b2
-    1 files updated, 0 files merged, 0 files removed, 0 files unresolved
-
     PS work> ant full-check
-    Buildfile: D:\hg\work\build.xml
+    Buildfile: D:\git\work\build.xml
 
-         [echo] Build is for release of 2.7.2b2.
+         [echo] Build is for release of 2.7.3a1.
 
-         [echo] jython.version            = '2.7.2b2'
+         [echo] jython.version            = '2.7.3a1'
 
 This time the script confirms it is a release
 and the version appears without the "SNAPSHOT" qualifier.
+
 If all remains well with the properties dumped, run the ``full-build`` target.
 This outputs the same dump as ``full-check`` and goes on to build the release artifacts.
-
 ``build.xml`` does not force a snapshot build on you now
 because the source tree is clean and the tag corresponds to the version.
 
@@ -275,6 +303,7 @@ The artifacts of interest are produced in the ``./dist`` directory and they are:
     These are not fatal to the build:
     they are a sign that our documentation is a bit shabby (and always was secretly).
 
+
 Gradle Build for Release
 ------------------------
 
@@ -289,7 +318,7 @@ working in folder ``./build2``.
 
     PS work> .\gradlew --console=plain publish
     > Task :generateVersionInfo
-    This build is for v2.7.2b2.
+    This build is for v2.7.3a1.
 
     > Task :generatePomFileForMainPublication
     > Task :generateGrammarSource
@@ -313,7 +342,7 @@ working in folder ``./build2``.
 
 When the build finishes, a JAR that is potentially fit to publish,
 and its subsidiary artifacts (source, javadoc, checksums),
-will have been created in ``./build2/stagingRepo/org/python/jython-slim/2.7.2b2``.
+will have been created in ``./build2/stagingRepo/org/python/jython-slim/2.7.3a1``.
 
 It can also be published to your local Maven cache (usually ``~/.m2/repository``
 with the task ``publishMainPublicationToMavenLocal``.
@@ -333,9 +362,9 @@ Let's use Java 11, different from the version we built with.
 
 ..  code-block:: ps1con
 
-    PS 272b-trial> mkdir kit
-    PS 272b-trial> copy "D:\hg\work\dist\jython*.jar" .\kit
-    PS 272b-trial> java -jar kit\jython-installer.jar
+    PS 273a1-trial> mkdir kit
+    PS 273a1-trial> copy "D:\git\work\dist\jython*.jar" .\kit
+    PS 273a1-trial> java -jar kit\jython-installer.jar
     WARNING: An illegal reflective access operation has occurred
     ...
     DEPRECATION: A future version of pip will drop support for Python 2.7.
@@ -346,20 +375,20 @@ It is worth checking the manifests:
 
 ..  code-block:: ps1con
 
-    PS 272b-trial> jar -xf .\kit\jython-standalone.jar META-INF
-    PS 272b-trial> cat .\META-INF\MANIFEST.MF
+    PS 273a1-trial> jar -xf .\kit\jython-standalone.jar META-INF
+    PS 273a1-trial> cat .\META-INF\MANIFEST.MF
     Manifest-Version: 1.0
     Ant-Version: Apache Ant 1.9.14
-    Created-By: 1.8.0_211-b12 (Oracle Corporation)
+    Created-By: 1.8.0_241-b07 (Oracle Corporation)
     Main-Class: org.python.util.jython
     Built-By: Jeff
     Implementation-Vendor: Python Software Foundation
     Implementation-Title: Jython fat jar with stdlib
-    Implementation-Version: 2.7.2b2
+    Implementation-Version: 2.7.3a1
 
     Name: Build-Info
-    version: 2.7.2b2
-    hg-build: true
+    version: 2.7.3a1
+    git-build: true
     oracle: true
     informix: true
     build-compiler: modern
@@ -376,10 +405,10 @@ The real test consists in running the regression tests:
 
 ..  code-block:: ps1con
 
-    PS 272b-trial> inst\bin\jython -m test.regrtest -e
-    == 2.7.2b2 (v2.7.2b2:b9b60766cabe, Nov 1 2019, 07:46:45)
+    PS 273a1-trial> inst\bin\jython -m test.regrtest -e
+    == 2.7.3a1 (tags/v2.7.3a1:625fdf3b1, Jun 2 2020, 20:06:45)
     == [Java HotSpot(TM) 64-Bit Server VM (Oracle Corporation)]
-    == platform: java11.0.3
+    == platform: java11.0.6
     == encodings: stdin=ms936, stdout=ms936, FS=utf-8
     == locale: default=('en_GB', 'GBK'), actual=(None, None)
     test_grammar
@@ -411,15 +440,14 @@ There will be many failures (34 when the author last tried).
 
 ..  code-block:: ps1con
 
-    PS 272b-trial> copy -r inst\Lib\test TestLib\test
-    PS 272b-trial> $env:JYTHONPATH = ".\TestLib"
-    PS 272b-trial> java -jar .\kit\jython-standalone.jar -m test.regrtest -e
-    == 2.7.2b2 (v2.7.2b2:b9b60766cabe, Nov 1 2019, 07:46:45)
+    PS 273a1-trial> copy -r inst\Lib\test TestLib\test
+    PS 273a1-trial> $env:JYTHONPATH = ".\TestLib"
+    PS 273a1-trial> java -jar .\kit\jython-standalone.jar -m test.regrtest -e
+    == 2.7.3a1 (tags/v2.7.3a1:625fdf3b1, Jun 2 2020, 20:06:45)
     == [Java HotSpot(TM) 64-Bit Server VM (Oracle Corporation)]
-    == platform: java11.0.3
+    == platform: java11.0.6
     == encodings: stdin=ms936, stdout=ms936, FS=utf-8
-    == locale: default=('en_GB', 'GBK'), actual=(None, None)
-    test_grammar
+    == locale: default=('en_GB', 'GBK'), actual=(None, None)    test_grammar
     test_opcodes
     ...
     34 fails unexpected:
@@ -460,7 +488,7 @@ For this, it is necessary to publish to a local repository, such as your persona
 
     PS work> .\gradlew --console=plain publishMainPublicationToMavenLocal
 
-This will deliver build artifacts to ``~/.m2/repository/org/python/jython-slim/2.7.2b2``.
+This will deliver build artifacts to ``~/.m2/repository/org/python/jython-slim/2.7.3a1``.
 One can construct an application to run with that as a dependency like this:
 
 ..  code-block:: groovy
@@ -479,7 +507,7 @@ One can construct an application to run with that as a dependency like this:
     }
 
     dependencies {
-        implementation 'org.python:jython-slim:2.7.2b2'
+        implementation 'org.python:jython-slim:2.7.3a1'
     }
 
 The following executes ``test.regrtest`` using the same local copy of the tests
@@ -501,23 +529,22 @@ and has about the same success rate.
     }
 
 
-Only now is it safe to ``hg push``
-----------------------------------
+Only now is it safe to ``git push``
+-----------------------------------
 
 If testing convinces you this is a build we should let loose on an unsuspecting public,
 it is time to push these changes and the tag you made upstream to the Jython repository.
-Back in the place where the release was built:
+Back in the place where the release was built (and using Bash):
 
-..  code-block:: ps1con
+..  code-block:: bash
 
-    PS work> hg push
+    $ git push --follow-tags
 
-It *is* possible to recover from tagging the wrong change set,
-even after a push.
-One may force in a duplicate tag (``hg tag -f v2.7.2b2``),
-and the later one seems to win in common tools,
-but both will be present in ``.hgtags``.
-It is better to avoid downstream confusion by not pushing forced tags.
+Try very hard not to push a tag you later regret
+(e.g. on the wrong change set or a version still needing a fix).
+It is problematic to `delete a tag after the push`_.
+It is better to increment the version,
+which is painless if it is an ``a``, ``b``, or ``rc`` release.
 
 
 Build the Bundles to Publish
@@ -528,7 +555,7 @@ The artifacts for Maven are built using a separate script ``maven/build.xml``.
 ..  code-block:: text
 
     PS work> ant -f maven\build.xml
-    Buildfile: D:\hg\work\maven\build.xml
+    Buildfile: D:\git\work\maven\build.xml
     ...
     BUILD SUCCESSFUL
     Total time: 24 seconds
@@ -538,17 +565,17 @@ During the build, ``gpg`` may prompt you (in a dialogue box)
 for the pass-phrase that protects your private signing key.
 This leaves the following new artifacts in ``./publications``:
 
-* ``jython-2.7.2b2-bundle.jar``
-* ``jython-standalone-2.7.2b2-bundle.jar``
-* ``jython-installer-2.7.2b2-bundle.jar``
-* ``jython-slim-2.7.2b2-bundle.jar``
+* ``jython-2.7.3a1-bundle.jar``
+* ``jython-standalone-2.7.3a1-bundle.jar``
+* ``jython-installer-2.7.3a1-bundle.jar``
+* ``jython-slim-2.7.3a1-bundle.jar``
 
 
 Publication
 ===========
 
-Pre-requisites
---------------
+Account
+-------
 
 In order to publish the bundles created in ``./publications``,
 it is necessary to have an account with access to ``groupId`` ``org.python``,
@@ -556,6 +583,11 @@ which Sonatype will grant given the support of an existing owner.
 (This is a human process administered through JIRA.)
 There is an extensive `Sonatype OSSRH Guide`_ about getting and using an account.
 These notes indicate a particular path that worked for the author.
+
+.. _PGP-signing:
+
+PGP Signing
+-----------
 
 You need a PGP signing key pair (generated with ``gpg --gen-key``)
 on the computer where you are working.
@@ -623,10 +655,10 @@ You are now ready to upload bundles acceptable to Sonatype.
 * On the "Staging Upload" tab, and the Upload Mode drop-down, select "Artifact Bundle".
 * Navigate to the ``./publications`` folder and upload in turn:
 
-  * ``jython-2.7.2b2-bundle.jar``
-  * ``jython-standalone-2.7.2b2-bundle.jar``
-  * ``jython-installer-2.7.2b2-bundle.jar``
-  * ``jython-slim-2.7.2b2-bundle.jar``
+  * ``jython-2.7.3a1-bundle.jar``
+  * ``jython-standalone-2.7.3a1-bundle.jar``
+  * ``jython-installer-2.7.3a1-bundle.jar``
+  * ``jython-slim-2.7.3a1-bundle.jar``
 
   For some reason the display shows a fake file path but the name is correct.
   Each upload creates a "staging repository".
@@ -693,9 +725,9 @@ incrementing ``jython.release_serial``.
 After a final release, assume the successor to be an alpha of the next micro-release.
 For example, ``2.7.2b2`` is followed by ``2.7.2b3``, and ``2.7.2`` by ``2.7.3a1``.
 
-The build system will label the code as ``2.7.2b3-DEV`` in the developer build.
-If you build an installer, or dry-run a release, it will be ``2.7.2b3-SNAPSHOT``.
-You can read this as a version that "may eventually become" ``2.7.2b3`` etc..
+The build system will label the code as ``2.7.3a2-DEV`` in the developer build.
+If you build an installer, or dry-run a release, it will be ``2.7.3a2-SNAPSHOT``.
+You can read this as a version that "may eventually become" ``2.7.3a2`` etc..
 
 Make this change in both ``build.xml`` and ``build.gradle``.
 See the section :ref:`changes-preparing-for-a-release` for details.


### PR DESCRIPTION
Remove (or demote) references to Mercurial and re-work the release process description.